### PR TITLE
dsh update and update scripts improvements

### DIFF
--- a/.docker/bin/dsh
+++ b/.docker/bin/dsh
@@ -347,7 +347,7 @@ update ()
 	if ! is_linux ; then
 		echo -e "${green}Installing boot2docker update...${NC}"
 		# get current version
-		local boot2docker_ver_path=$HOME/.drude/boot2docker_ver
+		local boot2docker_ver_path=$HOME/.drude/b2d_version
 		local boot2docker_ver=$(cat $boot2docker_ver_path)
 		if [ "$boot2docker_ver" = "" ]; then $boot2docker_ver="undetected version"; fi
 

--- a/.docker/bin/dsh
+++ b/.docker/bin/dsh
@@ -7,24 +7,35 @@ help ()
 	echo "Commands list:"
 	echo
 	echo "	init			Set up the project locally. Calls .docker/scripts/drude-init.sh"
+	echo
 	echo "	start (up)		Start vagrant vm (mac only) and docker containers -OR- restarts docker containers"
 	echo "	stop (down, halt)	Stop vagrant vm (mac only) or stop containers"
 	echo "	reload (restart)	Re-start vagrant vm (mac only) and docker containers"
+	echo "	status (st, ps)		Show containers status"
+	echo
 	echo "	reset			Restart docker containers from scratch (stop, remove, up)"
-	echo "	status (st, ps)		Show vm/containers status"
-	echo "	bash			Start bash on cli container"
+	echo
+	echo "	bash			Start bash on container. Default: cli (usage: dsh bash [container_name])"
 	echo "	exec (run)		Execute a command in cli container (usage: dsh exec <command> [param] [param] [param]...)"
+	echo
 	echo "	mysql			Opens mysql shell to drude database"
 	echo "	mysql-import		Truncate database and import from sql dump (usage: dsh mysql-import <dbdump.sql|dbdump.sql.gz>)"
-	echo "					Note: <filename> should be inside your project root"
-	echo "	drush			Shorthand for executing drush commands (usage: dsh drush [command] [options])"
-	echo "	cc			Shorthand for clearing caches (usage: dsh cc [cache_type] (\"dsh cc\" is equal to \"dsh cc all\")"
+	echo "					Note: DB dump file should be inside your project folder"
+	echo "	drush			Execute drush command (usage: dsh drush [command] [options])"
+	echo "	cc			Clear Drupal caches (usage: dsh cc [cache_type] (\"dsh cc\" is equal to \"dsh cc all\")"
+	echo
 	echo "	behat			Run Behat tests"
-	echo "	help			Output this help"
+	echo "	update			Update boot2docker and drude"
 	echo
 }
 
 #-------------------------- Helper functions --------------------------------
+
+# Console colors
+red='\033[0;31m'
+green='\033[0;32m'
+yellow='\033[1;33m'
+NC='\033[0m'
 
 # Search for file in current dir and all parent dirs
 # @param $1 filename
@@ -135,6 +146,16 @@ is_linux ()
 	fi
 }
 
+is_windows ()
+{
+	res=`uname | grep 'MINGW32_NT'`
+	if [[ ! "$res" == '' ]]; then
+		return 0;
+	else
+		return 1;
+	fi
+}
+
 # cheсks wether we are in boot2docker console
 is_boot2docker ()
 {
@@ -186,11 +207,20 @@ is_docker ()
 	return $?
 }
 
+is_vagrantfile_absent ()
+{
+	vagrant_path=`upfind "Vagrantfile"`
+	if [ "$vagrant_path" == "" ] ; then
+		echo "dsh: Vagrantfile not found in your directory tree"
+		return 0
+	fi
+
+	return 1
+}
+
 # Checks if yml or vagrantfile (win, mac) is absent
 is_yml_absent ()
 {
-	local vagrant_path=''
-
 	yml_path=`yml_get_path`
 	if [ "$yml_path" == "" ] ; then
 		echo "dsh: docker-compose.yml not found in your directory tree"
@@ -286,6 +316,84 @@ status ()
 		echo "${res}"
 		return 0
 	fi
+}
+
+update ()
+{
+	if is_boot2docker ; then
+		echo "dsh: You are running inside boot2docker"
+		return 1;
+	fi
+
+	if is_windows; then
+		echo "dsh: Update is not automated on Windows yet"
+		return 1;
+	fi
+
+	# run boot2docker update only on Mac and Win
+	if ! is_linux ; then
+		echo "Checking boot2docker version..."
+		# get current version
+		local boot2docker_ver_path=$HOME/.drude/boot2docker_ver
+		local boot2docker_ver=$(cat $boot2docker_ver_path)
+		if [ "$boot2docker_ver" = "" ]; then $boot2docker_ver="undetected version"; fi
+
+		# get new version
+		curl -sS https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/master/VERSION -o ${boot2docker_ver_path}_tmp
+		local boot2docker_new_ver=$(cat ${boot2docker_ver_path}_tmp)
+
+		# update boot2docker
+
+		local destroy_box=1;
+		if [ "$1" == "-f" ] || [ "$2" == "-f" ]; then boot2docker_new_ver="${boot2docker_new_ver} (forced update)"; fi
+		if [ "$1" == "-n" ] || [ "$2" == "-n" ]; then destroy_box=0; fi
+
+		if [ ! "$boot2docker_new_ver" = "$boot2docker_ver" ]; then
+			echo -e "boot2docker update available: ${green}$boot2docker_new_ver${NC} (you have $boot2docker_ver)."
+			if [ $destroy_box -eq 1 ]; then
+				echo -e "${red}Update will destroy and re-create your vagrant box${NC} (run with -n if you know re-creation can be skipped this time)"
+			else
+				echo -e "${green}Vagrant box will not be re-created${NC}"
+			fi
+			_confirm
+			# don't download update if we can't locate Vagrantfile
+			if is_vagrantfile_absent ; then return 1; fi
+			cd $vagrant_path
+			echo "Vagrantfile is found in "$(pwd)
+
+			echo "Creating backups..."
+			local timestamp=$(date +%s)
+			cp -v Vagrantfile $HOME/.drude/Vagrantfile.$timestamp
+			cp -v vagrant.yml $HOME/.drude/vagrant.yml.$timestamp
+
+			if [ $destroy_box -eq 1 ]; then
+				echo "Re-creating vagrant box..."
+				vagrant destroy -f
+			fi
+
+			echo "Downloading install script..."
+			curl -sS https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/master/setup.sh -o setup.sh
+			chmod +x setup.sh
+			source setup.sh # run boot2docker setup/update script
+
+			if [[ $? -ne 0 ]]; then
+				# don't continue in automatic mode if boot2docker update failed
+				return 1
+			else
+				# update recorded boot2docker version
+				cp ${boot2docker_ver_path}_tmp $boot2docker_ver_path
+				echo -e "boot2docker ${green}$boot2docker_new_ver${NC} was installed"
+			fi
+
+			#cleanup
+			rm setup.sh
+		else
+			echo "boot2docker $boot2docker_ver you have is the latest version (-f to force update)"
+		fi
+	fi
+
+	echo "Checking Drude version..."
+	curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/install-drude.sh | bash
 }
 
 # start interactive bash in container
@@ -495,6 +603,10 @@ case $1 in
 		;;
 	status)
 		status
+		;;
+	update)
+		shift
+		update $*
 		;;
 	st)
 		status

--- a/.docker/bin/dsh
+++ b/.docker/bin/dsh
@@ -29,13 +29,26 @@ help ()
 	echo
 }
 
-#-------------------------- Helper functions --------------------------------
-
 # Console colors
 red='\033[0;31m'
 green='\033[0;32m'
 yellow='\033[1;33m'
 NC='\033[0m'
+
+#-------------------------- Testing --------------------------------
+BOX_BRANCH='master'
+DRUDE_BRANCH='master'
+if [ ! $DRUDE_TEST_ENVIRONMENT == "" ]; then
+	DRUDE_BRANCH=$DRUDE_TEST_ENVIRONMENT
+fi
+if [ ! $BOOT2DOCKER_TEST_ENVIRONMENT == "" ]; then
+	BOX_BRANCH=$BOOT2DOCKER_TEST_ENVIRONMENT
+fi
+if [ ! $BOX_BRANCH == 'master' ] || [ ! $DRUDE_BRANCH == 'master' ]; then
+	echo -e "${red}[dsh] testing mode: boot2docker - ${BOX_BRANCH}, drude - ${DRUDE_BRANCH}$NC"
+fi
+
+#-------------------------- Helper functions --------------------------------
 
 # Search for file in current dir and all parent dirs
 # @param $1 filename
@@ -332,14 +345,19 @@ update ()
 
 	# run boot2docker update only on Mac and Win
 	if ! is_linux ; then
-		echo "Checking boot2docker version..."
+		echo -e "${green}Installing boot2docker update...${NC}"
 		# get current version
 		local boot2docker_ver_path=$HOME/.drude/boot2docker_ver
 		local boot2docker_ver=$(cat $boot2docker_ver_path)
 		if [ "$boot2docker_ver" = "" ]; then $boot2docker_ver="undetected version"; fi
 
 		# get new version
-		curl -sS https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/master/VERSION -o ${boot2docker_ver_path}_tmp
+		curl -fsS https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/$BOX_BRANCH/VERSION -o ${boot2docker_ver_path}_tmp
+		if [ ! $? -eq 0 ]; then
+			echo -e "${red}Could not get latest boot2docker version. Please check your internet connection${NC}"
+			exit
+		fi
+
 		local boot2docker_new_ver=$(cat ${boot2docker_ver_path}_tmp)
 
 		# update boot2docker
@@ -351,15 +369,25 @@ update ()
 		if [ ! "$boot2docker_new_ver" = "$boot2docker_ver" ]; then
 			echo -e "boot2docker update available: ${green}$boot2docker_new_ver${NC} (you have $boot2docker_ver)."
 			if [ $destroy_box -eq 1 ]; then
-				echo -e "${red}Update will destroy and re-create your vagrant box${NC} (run with -n if you know re-creation can be skipped this time)"
+				echo -e "${red}Update will destroy and re-create your Vagrant box${NC} (run with -n if you know re-creation can be skipped this time)"
+				_confirm "Please confirm."
 			else
 				echo -e "${green}Vagrant box will not be re-created${NC}"
 			fi
-			_confirm
+
 			# don't download update if we can't locate Vagrantfile
 			if is_vagrantfile_absent ; then return 1; fi
 			cd $vagrant_path
 			echo "Vagrantfile is found in "$(pwd)
+
+			echo -n "Downloading boot2docker install script..."
+			curl -fsS https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/$BOX_BRANCH/setup.sh -o setup.sh
+			if [ ! $? -eq 0 ]; then
+				echo -e "${red}Could not get latest boot2docker version. Please check your internet connection${NC}"
+				exit
+			fi
+			echo "done"
+			chmod +x setup.sh
 
 			echo "Creating backups..."
 			local timestamp=$(date +%s)
@@ -367,14 +395,12 @@ update ()
 			cp -v vagrant.yml $HOME/.drude/vagrant.yml.$timestamp
 
 			if [ $destroy_box -eq 1 ]; then
-				echo "Re-creating vagrant box..."
+				echo -e "${yellow}Destroying vagrant box...$NC"
 				vagrant destroy -f
 			fi
 
-			echo "Downloading install script..."
-			curl -sS https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/master/setup.sh -o setup.sh
-			chmod +x setup.sh
-			source setup.sh # run boot2docker setup/update script
+			echo "${yellow}Running boot2docker install script...$NC"
+			source setup.sh
 
 			if [[ $? -ne 0 ]]; then
 				# don't continue in automatic mode if boot2docker update failed
@@ -392,8 +418,15 @@ update ()
 		fi
 	fi
 
-	echo "Checking Drude version..."
-	curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/install-drude.sh | bash
+	echo -n "Downloading drude install script..."
+	curl -fsS https://raw.githubusercontent.com/blinkreaction/drude/$DRUDE_BRANCH/install-drude.sh >/dev/null
+	if [ ! $? -eq 0 ]; then
+		echo -e "${red}Update interrupted. Could not get latest Drude version. Please check your internet connection${NC}"
+		exit
+	else
+		echo "done"
+		curl -fsS https://raw.githubusercontent.com/blinkreaction/drude/$DRUDE_BRANCH/install-drude.sh | bash
+	fi
 }
 
 # start interactive bash in container

--- a/.docker/bin/dsh
+++ b/.docker/bin/dsh
@@ -111,7 +111,7 @@ get_drush_path ()
 		echo "dsh supports '$argv' command only from within project directory"
 		return 1
 	fi
-	if [ "$pathdiff" == "" ]; then
+	if [ "$pathdiff" == "" ]; then # we're on top level, let's cd for drush to work
 		cd docroot
 	fi
 	return 0
@@ -467,11 +467,12 @@ run ()
 # param $* command with it's params to run
 _run ()
 {
+	local COLS=$(tput cols) #get client window width
 	if is_yml_absent ; then return 2; fi
 	if is_docker && is_docker_compose ; then
 		local cd_path=''
 		cmdpath cd_path
-		run "cd $cd_path && $*"
+		run "cd $cd_path && export COLUMNS=$COLS && $*"
 	fi
 }
 

--- a/.docker/bin/dsh
+++ b/.docker/bin/dsh
@@ -263,19 +263,17 @@ is_yml_absent ()
 # bring box up
 up ()
 {
-	echo "Checking files..."
 	if is_yml_absent ; then return 2; fi
 	if is_vagrant ; then
-		echo "Starting vagrant vm..."
 		vagrant up
 		started=$?
 		if [ $started -eq 0 ] && is_docker_compose ; then
-			echo "Starting containers..."
+			echo -e "${green}Starting containers...$NC"
 			cd `yml_get_path`
 			docker-compose up -d
 		fi
 	elif ( is_boot2docker || is_linux ) && is_docker_compose ; then
-		echo "Starting containers..."
+		echo -e "${green}Starting containers...$NC"
 		cd `yml_get_path`
 		docker-compose up -d
 	fi
@@ -286,10 +284,9 @@ down ()
 {
 	if is_yml_absent ; then return 2; fi
 	if is_vagrant ; then
-		echo "Stopping vagrant vm..."
 		vagrant halt
 	elif ( is_boot2docker || is_linux ) && is_docker_compose ; then
-		echo "Stopping containers..."
+		echo -e "${yellow}Stopping containers...$NC"
 		cd `yml_get_path`
 		docker-compose stop
 	fi
@@ -298,19 +295,17 @@ down ()
 # call 911
 restart ()
 {
-	echo "Checking files..."
 	if is_yml_absent ; then return 2; fi
 	if is_vagrant ; then
-		echo "Restarting vagrant vm..."
 		vagrant reload
 		started=$?
 		if [ $started -eq 0 ] && is_docker_compose ; then
-			echo "Starting containers..."
+			echo -e "${green}Starting containers...$NC"
 			cd `yml_get_path`
 			docker-compose up -d
 		fi
 	elif ( is_boot2docker || is_linux ) && is_docker_compose ; then
-		echo "Restarting containers..."
+		echo -e "${green}Restarting containers...$NC"
 		cd `yml_get_path`
 		docker-compose up -d
 	fi
@@ -328,7 +323,7 @@ status ()
 	# check docker compose output to not be $compose_error
 	res=$(docker-compose ps 2>&1)
 	if [ "$res" == "$compose_error" ]; then
-		echo "Drude is not running. Use 'dsh up' to start it"
+		echo -e "${yellow}Drude is not running. Use 'dsh up' to start it$NC"
 		return 1
 	else
 		echo "${res}"
@@ -339,12 +334,12 @@ status ()
 update ()
 {
 	if is_boot2docker ; then
-		echo "dsh: You are running inside boot2docker"
+		echo -e "${red}dsh: You are running inside boot2docker$NC"
 		return 1;
 	fi
 
 	if is_windows; then
-		echo "dsh: Update is not automated on Windows yet"
+		echo -e "${red}dsh: Update is not automated on Windows yet$NC"
 		return 1;
 	fi
 
@@ -423,6 +418,7 @@ update ()
 		fi
 	fi
 
+	# Update drude
 	echo -n "Downloading drude install script..."
 	curl -fsS https://raw.githubusercontent.com/blinkreaction/drude/$DRUDE_BRANCH/install-drude.sh >/dev/null
 	if [ ! $? -eq 0 ]; then
@@ -431,6 +427,15 @@ update ()
 	else
 		echo "done"
 		curl -fsS https://raw.githubusercontent.com/blinkreaction/drude/$DRUDE_BRANCH/install-drude.sh | bash
+		if [ $? -eq 0 ]; then # start conatiners only if drude was updated fine
+			if [ ! "$boot2docker_new_ver" = "$boot2docker_ver" ] && [ $destroy_box -eq 1 ]; then
+				# if vagrant box was updated containers will be downloaded again
+				_confirm "Downloading and starting containers."
+			else
+				_confirm "Starting containers. If there's an update to container images it will be downloaded."
+				up
+			fi
+		fi
 	fi
 }
 

--- a/.docker/bin/dsh
+++ b/.docker/bin/dsh
@@ -352,13 +352,11 @@ update ()
 		if [ "$boot2docker_ver" = "" ]; then $boot2docker_ver="undetected version"; fi
 
 		# get new version
-		curl -fsS https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/$BOX_BRANCH/VERSION -o ${boot2docker_ver_path}_tmp
+		local boot2docker_new_ver=$(curl -fsS https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/$BOX_BRANCH/VERSION)
 		if [ ! $? -eq 0 ]; then
 			echo -e "${red}Could not get latest boot2docker version. Please check your internet connection${NC}"
-			exit
+			return 1
 		fi
-
-		local boot2docker_new_ver=$(cat ${boot2docker_ver_path}_tmp)
 
 		# update boot2docker
 
@@ -381,13 +379,12 @@ update ()
 			echo "Vagrantfile is found in "$(pwd)
 
 			echo -n "Downloading boot2docker install script..."
-			curl -fsS https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/$BOX_BRANCH/setup.sh -o setup.sh
+			local setup_script=$(curl -fsS https://raw.githubusercontent.com/blinkreaction/boot2docker-vagrant/$BOX_BRANCH/setup.sh)
 			if [ ! $? -eq 0 ]; then
 				echo -e "${red}Could not get latest boot2docker version. Please check your internet connection${NC}"
 				exit
 			fi
 			echo "done"
-			chmod +x setup.sh
 
 			echo "Creating backups..."
 			local timestamp=$(date +%s)
@@ -400,19 +397,16 @@ update ()
 			fi
 
 			echo "${yellow}Running boot2docker install script...$NC"
-			source setup.sh
+			echo $setup_script | bash
 
 			if [[ $? -ne 0 ]]; then
 				# don't continue in automatic mode if boot2docker update failed
 				return 1
 			else
 				# update recorded boot2docker version
-				cp ${boot2docker_ver_path}_tmp $boot2docker_ver_path
+				echo $boot2docker_new_ver > $boot2docker_ver_path
 				echo -e "boot2docker ${green}$boot2docker_new_ver${NC} was installed"
 			fi
-
-			#cleanup
-			rm setup.sh
 		else
 			echo "boot2docker $boot2docker_ver you have is the latest version (-f to force update)"
 		fi
@@ -420,21 +414,21 @@ update ()
 
 	# Update drude
 	echo -n "Downloading drude install script..."
-	curl -fsS https://raw.githubusercontent.com/blinkreaction/drude/$DRUDE_BRANCH/install-drude.sh >/dev/null
+	local drude_install_script=$(curl -fsS https://raw.githubusercontent.com/blinkreaction/drude/$DRUDE_BRANCH/install-drude.sh)
 	if [ ! $? -eq 0 ]; then
 		echo -e "${red}Update interrupted. Could not get latest Drude version. Please check your internet connection${NC}"
-		exit
+		return 1
 	else
 		echo "done"
-		curl -fsS https://raw.githubusercontent.com/blinkreaction/drude/$DRUDE_BRANCH/install-drude.sh | bash
+		echo $drude_install_script | bash
 		if [ $? -eq 0 ]; then # start conatiners only if drude was updated fine
 			if [ ! "$boot2docker_new_ver" = "$boot2docker_ver" ] && [ $destroy_box -eq 1 ]; then
 				# if vagrant box was updated containers will be downloaded again
 				_confirm "Downloading and starting containers."
 			else
 				_confirm "Starting containers. If there's an update to container images it will be downloaded."
-				up
 			fi
+			up
 		fi
 	fi
 }

--- a/.docker/bin/dsh
+++ b/.docker/bin/dsh
@@ -102,12 +102,17 @@ get_project_root_path ()
 # dummy function to check that command is run along settings.php
 get_drush_path ()
 {
-	local docroot=$(get_project_root_path)'/docroot'
+	# Check that we're inside project folder
+	local proj_root=$(get_project_root_path)
 	local cwd=$(pwd)
-	local pathdiff=${cwd#$docroot}
+	# if cwd substract proj_root is still cwd then it means we're out of proj_root
+	local pathdiff=${cwd#$proj_root}
 	if [ "$cwd" == "$pathdiff" ]; then
-		echo "dsh supports '$argv' command only from docroot directory or directory that contains settings.php"
+		echo "dsh supports '$argv' command only from within project directory"
 		return 1
+	fi
+	if [ "$pathdiff" == "" ]; then
+		cd docroot
 	fi
 	return 0
 }

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -10,8 +10,30 @@ NC='\033[0m'
 DRUDE_REPO='https://github.com/blinkreaction/drude.git'
 DRUDE_REPO_RAW='https://raw.githubusercontent.com/blinkreaction/drude/master'
 
+# Yes/no confirmation dialog with an optional message
+# @param $1 confirmation message
+_confirm ()
+{
+	while true; do
+		read -p "$1Continue? [y/n]: " answer
+		case $answer in
+			[Yy]|[Yy][Ee][Ss] )
+				echo "Working..."
+				break
+				;;
+			[Nn]|[Nn][Oo] )
+				echo 'Ok, whatever.'
+				exit 1
+				;;
+			* )
+				echo 'Please answer yes or no.'
+		esac
+	done
+}
+
+echo "Updating dsh"
 # Install/update dsh tool wrapper
-curl -s "$DRUDE_REPO_RAW/install.sh" | bash
+curl -s "$DRUDE_REPO_RAW/install-dsh.sh" | bash
 
 # Check that git binary is available
 type git > /dev/null 2>&1 || { echo -e >&2 "${red}No git? Srsly? \n${yellow}Please install git then come back. Aborting...${NC}"; exit 1; }
@@ -19,8 +41,9 @@ type git > /dev/null 2>&1 || { echo -e >&2 "${red}No git? Srsly? \n${yellow}Plea
 # Check if current directory is a Git repository
 if [[ -z $(git rev-parse --git-dir 2>/dev/null) ]]; then
 	# If there is no git repo - initialize one and commit everything before we proceed
-	echo -e "${yellow}No git repository! We'll create one to proceed witht he install.${NC}"
-	echo -e "${green}Initializing a git repo and commiting everything.${NC}"
+	echo -e "${yellow}No git repository! We'll create one to proceed with the install.${NC}"
+	echo -e "${green}Going to initialize a git repo and commit everything.${NC}"
+	_confirm "Initializing new git repo in $(pwd). "
 	git init -q && git add -A && git commit -q -m 'Initial commit'
 fi
 
@@ -32,21 +55,21 @@ if [[ $(git rev-parse --git-dir) != '.git' ]]; then
 fi
 
 # Check if the working tree and index are clean
-if [[ -n $(git status -s) ]]; then
+if [[ -n $(git status .docker docker-compose.yml -s) ]]; then
 	echo -e "${red}Your git working tree or index is not clean."
-	echo -e "Please stage/stash and commit any pending changes before proceeding with the update.${NC}"
-	exit 1
+	echo -e "It is recommended to commit any pending changes before proceeding with the update.${NC}"
+	_confirm "Going to overwrite changes to .docker/ and docker-compose.yml. "
 fi
 
 # Checking out the most recent Drude build
 git remote add drude $DRUDE_REPO
-git remote update
+git remote update drude
 git checkout drude/build .
 git remote rm drude
 
-if [[ -n $(git status -s) ]]; then
-	echo -e "${green}Installed/updated Drude at version $(cat .docker/VERSION)${NC}"
-	echo -e "${yellow}Please review tha changes and commit them into your repo!${NC}"
+if [[ -n $(git status .docker docker-compose.yml -s) ]]; then
+	echo -e "${green}Installed/updated Drude to version $(cat .docker/VERSION)${NC}"
+	echo -e "${yellow}Please review the changes and commit them into your repo!${NC}"
 else
-	echo -e "${yellow}You already have the most recent build of Drude!${NC}"
+	echo -e "${yellow}You already have the most recent build of Drude${NC}"
 fi

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -81,7 +81,7 @@ fi
 # Checking out the most recent Drude build
 git remote add drude $DRUDE_REPO
 git remote update drude 1>/dev/null
-git checkout --theirs drude/devel .
+git checkout --theirs drude/build .
 git remote rm drude
 
 if [[ -n $(git status .docker docker-compose.yml -s) ]]; then

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -72,7 +72,7 @@ fi
 
 # Check if the working tree and index are clean
 if [[ -n $(git status .docker docker-compose.yml -s) ]]; then
-	echo -e "${yellow}Your have uncommitted changes in following files:${NC}"
+	echo -e "${yellow}You have uncommitted changes in following files:${NC}"
 	git status .docker docker-compose.yml -s
 	echo -e "${yellow}Before proceeding with the update it is recommended to commit any pending changes in files above.$NC"
 	_confirm "Proceeding will overwrite your changes. Continue?"

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -28,6 +28,7 @@ _confirm ()
 				break
 				;;
 			[Nn]|[Nn][Oo] )
+				return 1
 				exit 1
 				;;
 			* )

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -6,23 +6,28 @@ green='\033[0;32m'
 yellow='\033[1;33m'
 NC='\033[0m'
 
+# For testing
+BRANCH='master'
+if [ ! $DRUDE_TEST_ENVIRONMENT == "" ]; then
+	BRANCH=$DRUDE_TEST_ENVIRONMENT
+	echo -e "${red}[install-drude] testing mode: environment = \"${BRANCH}\"$NC"
+fi
+
 # Drude repo
-DRUDE_REPO='https://github.com/blinkreaction/drude.git'
-DRUDE_REPO_RAW='https://raw.githubusercontent.com/blinkreaction/drude/master'
+DRUDE_REPO="https://github.com/blinkreaction/drude.git"
+DRUDE_REPO_RAW="https://raw.githubusercontent.com/blinkreaction/drude/$BRANCH"
 
 # Yes/no confirmation dialog with an optional message
 # @param $1 confirmation message
 _confirm ()
 {
 	while true; do
-		read -p "$1Continue? [y/n]: " answer
+		read -p "$1 [y/n]: " answer
 		case $answer in
 			[Yy]|[Yy][Ee][Ss] )
-				echo "Working..."
 				break
 				;;
 			[Nn]|[Nn][Oo] )
-				echo 'Ok, whatever.'
 				exit 1
 				;;
 			* )
@@ -31,10 +36,21 @@ _confirm ()
 	done
 }
 
-echo "Updating dsh"
 # Install/update dsh tool wrapper
-curl -s "$DRUDE_REPO_RAW/install-dsh.sh" | bash
+curl -fsS "$DRUDE_REPO_RAW/install-dsh.sh" -o install-dsh.sh
+if [ $? -eq 0 ]; then
+	source install-dsh.sh
+	dsh_success=$?
+	rm install-dsh.sh
+	if [ ! $dsh_success -eq 0 ]; then
+		_confirm "Do you want to continue with drude update regardless?"
+	fi
+else
+	echo -e "${red}Could not get install-dsh script.${NC}"
+	_confirm "Do you want to continue with drude update regardless?"
+fi
 
+echo -e "${green}Installing Drude update...${NC}"
 # Check that git binary is available
 type git > /dev/null 2>&1 || { echo -e >&2 "${red}No git? Srsly? \n${yellow}Please install git then come back. Aborting...${NC}"; exit 1; }
 
@@ -43,28 +59,29 @@ if [[ -z $(git rev-parse --git-dir 2>/dev/null) ]]; then
 	# If there is no git repo - initialize one and commit everything before we proceed
 	echo -e "${yellow}No git repository! We'll create one to proceed with the install.${NC}"
 	echo -e "${green}Going to initialize a git repo and commit everything.${NC}"
-	_confirm "Initializing new git repo in $(pwd). "
+	_confirm "Do you want to initialize new git repo in $(pwd)?"
 	git init -q && git add -A && git commit -q -m 'Initial commit'
 fi
 
 # Make sure we are in the root of a git repository
 if [[ $(git rev-parse --git-dir) != '.git' ]]; then
 	GIT_ROOT=$(git rev-parse --show-toplevel)
-	echo -e "${yellow}This script must be run from the git repo root. Switching to $GIT_ROOT.${NC}"
+	echo "Switching to git repo root: $GIT_ROOT"
 	cd $GIT_ROOT
 fi
 
 # Check if the working tree and index are clean
 if [[ -n $(git status .docker docker-compose.yml -s) ]]; then
-	echo -e "${red}Your git working tree or index is not clean."
-	echo -e "It is recommended to commit any pending changes before proceeding with the update.${NC}"
-	_confirm "Going to overwrite changes to .docker/ and docker-compose.yml. "
+	echo -e "${yellow}Your have uncommitted changes in following files:${NC}"
+	git status .docker docker-compose.yml -s
+	echo -e "${yellow}Before proceeding with the update it is recommended to commit any pending changes in files above.$NC"
+	_confirm "Proceeding will overwrite your changes. Continue?"
 fi
 
 # Checking out the most recent Drude build
 git remote add drude $DRUDE_REPO
-git remote update drude
-git checkout drude/build .
+git remote update drude 1>/dev/null
+git checkout --theirs drude/devel .
 git remote rm drude
 
 if [[ -n $(git status .docker docker-compose.yml -s) ]]; then

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -38,12 +38,10 @@ _confirm ()
 }
 
 # Install/update dsh tool wrapper
-curl -fsS "$DRUDE_REPO_RAW/install-dsh.sh" -o install-dsh.sh
+local dsh_install_script=$(curl -fsS "$DRUDE_REPO_RAW/install-dsh.sh")
 if [ $? -eq 0 ]; then
-	source install-dsh.sh
-	dsh_success=$?
-	rm install-dsh.sh
-	if [ ! $dsh_success -eq 0 ]; then
+	echo $dsh_install_script | bash
+	if [ ! $? -eq 0 ]; then
 		_confirm "Do you want to continue with drude update regardless?"
 	fi
 else

--- a/install-dsh.sh
+++ b/install-dsh.sh
@@ -40,6 +40,7 @@ $SUDO touch "$BIN/dsh" 2> /dev/null || {
 # Install/update dsh tool wrapper
 curl -fsS "$DRUDE_REPO_RAW/scripts/dsh-wrapper.sh" -o "$BIN/dsh-new"
 if [ ! $? -eq 0 ]; then
+	rm "$BIN/dsh-new" 2>dev/null
 	echo -e "${red}Could not get latest dsh wrapper version.${NC}"
 	return 1
 	exit 1

--- a/install-dsh.sh
+++ b/install-dsh.sh
@@ -33,19 +33,16 @@ $SUDO touch "$BIN/dsh" 2> /dev/null || {
 $SUDO touch "$BIN/dsh" 2> /dev/null || {
 	echo -e "${yellow}Could not write to $BIN/dsh.${NC}";
 	echo -e "${red}Could not install dsh wrapper tool${NC}";
-	return 1;
 	exit 1;
 }
 
 # Install/update dsh tool wrapper
-curl -fsS "$DRUDE_REPO_RAW/scripts/dsh-wrapper.sh" -o "$BIN/dsh-new"
+local dsh_wrapper=$(curl -fsS "$DRUDE_REPO_RAW/scripts/dsh-wrapper.sh")
 if [ ! $? -eq 0 ]; then
-	rm "$BIN/dsh-new" 2>dev/null
 	echo -e "${red}Could not get latest dsh wrapper version.${NC}"
-	return 1
 	exit 1
 else
-	$SUDO mv "$BIN/dsh-new" "$BIN/dsh"
+	echo $dsh_wrapper | $SUDO tee "$BIN/dsh" >/dev/null
 	$SUDO chmod +x "$BIN/dsh"
 	echo -e "${green}dsh wrapper was installed as${NC}${yellow} $BIN/dsh${NC}"
 fi

--- a/install-dsh.sh
+++ b/install-dsh.sh
@@ -6,18 +6,45 @@ green='\033[0;32m'
 yellow='\033[1;33m'
 NC='\033[0m'
 
-# Drude repo
-DRUDE_REPO='https://github.com/blinkreaction/drude.git'
-DRUDE_REPO_RAW='https://raw.githubusercontent.com/blinkreaction/drude/master'
+# For testing
+BRANCH='master'
+if [ ! $DRUDE_TEST_ENVIRONMENT == "" ]; then
+	BRANCH=$DRUDE_TEST_ENVIRONMENT
+	echo -e "${red}[install-dsh] testing mode: environment = \"${BRANCH}\"$NC"
+fi
 
+# Drude repo
+DRUDE_REPO="https://github.com/blinkreaction/drude.git"
+DRUDE_REPO_RAW="https://raw.githubusercontent.com/blinkreaction/drude/$BRANCH"
+
+echo -e "${green}Installing/updating dsh tool wrapper. Admin access required${NC}"
 # Determine if we have sudo
 SUDO='sudo'
 if [[ -z $(which $SUDO) ]]; then SUDO=''; fi
+
 # Detemine where we can install (/usb/local/bin or /bin)
 BIN='/usr/local/bin'
-$SUDO touch "$BIN/dsh" 2> /dev/null || BIN="/bin"
-$SUDO touch "$BIN/dsh" 2> /dev/null || { echo -e "${yellow}Warning: Not able to install dsh.${NC}"; }
+
+$SUDO touch "$BIN/dsh" 2> /dev/null || {
+	echo -e "${yellow}Could not write to $BIN/dsh.${NC}";
+	BIN="/bin";
+}
+
+$SUDO touch "$BIN/dsh" 2> /dev/null || {
+	echo -e "${yellow}Could not write to $BIN/dsh.${NC}";
+	echo -e "${red}Could not install dsh wrapper tool${NC}";
+	return 1;
+	exit 1;
+}
+
 # Install/update dsh tool wrapper
-echo -e "${green}Installing/updating dsh (Drude Shell) tool wrapper to $BIN/dsh${NC}"
-curl -s "$DRUDE_REPO_RAW/scripts/dsh-wrapper.sh" | $SUDO tee 1>/dev/null "$BIN/dsh"
-$SUDO chmod +x "$BIN/dsh"
+curl -fsS "$DRUDE_REPO_RAW/scripts/dsh-wrapper.sh" -o "$BIN/dsh-new"
+if [ ! $? -eq 0 ]; then
+	echo -e "${red}Could not get latest dsh wrapper version.${NC}"
+	return 1
+	exit 1
+else
+	$SUDO mv "$BIN/dsh-new" "$BIN/dsh"
+	$SUDO chmod +x "$BIN/dsh"
+	echo -e "${green}dsh wrapper was installed as${NC}${yellow} $BIN/dsh${NC}"
+fi


### PR DESCRIPTION
- dsh: new update command that updates boot2docker and drude
- install-drude now better handles errors and has less requirements
- install-dsh now better handles errors
- all 3 scripts now support testing. Use DRUDE_TESTING_ENVIRONMENT and BOOT2DOCKER_TESTING_ENVIRONMENT environment variables to choose default branches (by default they both use 'master')

**Note:** install-drude.sh always checks out drude/build branch regardless of DRUDE_TESTING settings but it downloads install-sdh.sh from DRUDE_TESTING branch
**Note:** boot2docker scripts (setup, presetup) need to be updated to support testing branches
