### PR TITLE
install-drude.sh small fix, readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Docker and Docker Compose based environment for Drupal.
 <a name="requirements"></a>
 ## Requirements
 
-Docker is natively supported only on Linux.  
+Docker is natively supported only on Linux.
 Mac and Windows users will need a tiny linux VM layer - [Boot2docker Vagrant Box](https://github.com/blinkreaction/boot2docker-vagrant)
 
 ### Mac
@@ -41,13 +41,13 @@ Mac and Windows users will need a tiny linux VM layer - [Boot2docker Vagrant Box
 <a name="setup"></a>
 ## Setup
 
-Drude initial setup is done once per project (e.g. by a team lead).  
-Once installed into the project repo, Drude can be used by anyone on the team.  
+Drude initial setup is done once per project (e.g. by a team lead).
+Once installed into the project repo, Drude can be used by anyone on the team.
 To use Drude each team member will need to meet the [requirements](#requirements) outlined above.
 
 `docker-compose.yml` file and `.docker` folder are good indicators of Drude's presence in the project repo.
 
-**If this is the first time Drude is being installed into the project, follow the instructions below.**  
+**If this is the first time Drude is being installed into the project, follow the instructions below.**
 
 The installation process is slightly different based on the OS.
 
@@ -58,9 +58,9 @@ The installation process is slightly different based on the OS.
  3. cd `</path/to/project>` and run:
 
     ```
-    bash <(curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/scripts/install-drude.sh)
+    bash <(curl -s https://raw.githubusercontent.com/blinkreaction/drude/develop/scripts/install-drude.sh)
     ```
-    
+
  4. Start containers with `dsh up`
 
 ### Windows
@@ -70,11 +70,11 @@ The installation process is slightly different based on the OS.
  3. Open Git Bash shell and cd into `</path/to/project>`, then run:
 
     ```
-    bash <(curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/scripts/install-drude.sh)
+    bash <(curl -s https://raw.githubusercontent.com/blinkreaction/drude/develop/scripts/install-drude.sh)
     ```
-    
+
  4. Start and login into vagrant, cd into `</path/to/project>`:
- 
+
     ```
     vagrant up
     vagrant ssh
@@ -90,7 +90,7 @@ The installation process is slightly different based on the OS.
  3. cd `</path/to/project>` and run:
 
     ```
-    bash <(curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/scripts/install-drude.sh)
+    bash <(curl -s https://raw.githubusercontent.com/blinkreaction/drude/develop/scripts/install-drude.sh)
     ```
 
  4. Start containers with `dsh up`
@@ -100,7 +100,7 @@ The installation process is slightly different based on the OS.
 
 To update Drude run the following from the `</path/to/project>` folder:
 
-    bash <(curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/scripts/install-drude.sh)
+    bash <(curl -s https://raw.githubusercontent.com/blinkreaction/drude/develop/scripts/install-drude.sh)
 
 Review the changes, revert any local overrides that were reset and commit into your project git repo.
 
@@ -136,7 +136,7 @@ It runs on Mac/Linux directly. On Windows `dsh` runs inside the boot2docker VM.
 
 ### Installation
 
-    bash <(curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/scripts/install-dsh.sh)
+    bash <(curl -s https://raw.githubusercontent.com/blinkreaction/drude/develop/scripts/install-dsh.sh)
 
 This will install a local dsh wrapper into `/usr/local/bin/dsh`.
 The actual dsh script resides in each project individually (in `.docker/bin/dsh`) and is installed into the project along with Drude. The wrapper makes it possible to use `dsh` from anywhere in the project tree.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ web:
     - "80"
     - "443"
     # Use IP based mapping when working with multiple projects. See docs (^^) for more details.
-    #- 192.168.10.10:80:80 
-    #- 192.168.10.10:443:443 
+    #- 192.168.10.10:80:80
+    #- 192.168.10.10:443:443
   volumes_from:
     - cli
   links:
@@ -51,7 +51,7 @@ cli:
     - ~/.ssh:/.ssh   # Linux
     # PHP configuration overrides
     - "./.drude/etc/php5/php.ini:/etc/php5/fpm/conf.d/z_php.ini"
-    - "./.drude/etc/php5/php-cli.ini:/etc/php5/fpm/conf.d/z_php.ini"
+    - "./.drude/etc/php5/php-cli.ini:/etc/php5/cli/conf.d/z_php.ini"
     # Project root folder mapping
     - ".:/var/www"
   links:

--- a/scripts/install-drude.sh
+++ b/scripts/install-drude.sh
@@ -29,7 +29,7 @@ is_tty ()
 # {
 # 	# Skip checks if not a tty
 # 	if ! is_tty ; then return 0; fi
-	
+
 # 	while true; do
 # 		read -p "$1 [y/n]: " answer
 # 		case $answer in
@@ -43,7 +43,7 @@ is_tty ()
 # 				echo 'Please answer yes or no.'
 # 		esac
 # 	done
-}
+# }
 
 # Install/update dsh tool wrapper
 # dsh_install_script=$(curl -fsS "$DRUDE_REPO_RAW/install-dsh.sh")


### PR DESCRIPTION
- install-drude.sh _confirm was commented out except for last line causing error on execution.
- readme links were pointing to develop for install but for setup they were pointing to master. Most of the people probably use develop at this point so this needs to be consistent.
