### PR TITLE
Changed scripts in master and build branches to use /bin/bash 

### DIFF
--- a/.docker/bin/dsh
+++ b/.docker/bin/dsh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 help ()
 {

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The installation process is slightly different based on the OS.
  3. cd `</path/to/project>` and run:
 
     ```
-    curl -s https://raw.githubusercontent.com/frederickjh/drude/master/install-drude.sh | bash
+    curl -s https://raw.githubusercontent.com/frederickjh/drude/master/install-drude.sh | bash 2>/dev/null
     ```
 
  4. Start containers with `dsh up`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Drude (**Dru**pal **D**ocker **E**nvironment)
 Docker and Docker Compose based environment for Drupal.
 
-[![Circle CI](https://circleci.com/gh/frederickjh/drude.svg?style=shield)](https://circleci.com/gh/blinkreaction/drude)
+[![Circle CI](https://circleci.com/gh/blinkreaction/drude.svg?style=shield)](https://circleci.com/gh/blinkreaction/drude)
 
 <a name="requirements"></a>
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # Drude (**Dru**pal **D**ocker **E**nvironment)
 Docker and Docker Compose based environment for Drupal.
 
-[![Circle CI](https://circleci.com/gh/blinkreaction/drude.svg?style=shield)](https://circleci.com/gh/blinkreaction/drude)
+[![Circle CI](https://circleci.com/gh/frederickjh/drude.svg?style=shield)](https://circleci.com/gh/frederickjh/drude)
 
 <a name="requirements"></a>
 ## Requirements
 
 Docker is natively supported only on Linux.  
-Mac and Windows users will need a tiny linux VM layer - [Boot2docker Vagrant Box](https://github.com/blinkreaction/boot2docker-vagrant)
+Mac and Windows users will need a tiny linux VM layer - [Boot2docker Vagrant Box](https://github.com/frederickjh/boot2docker-vagrant)
 
 ### Mac and Windows
 
-1. Get the [Boot2docker Vagrant Box](https://github.com/blinkreaction/boot2docker-vagrant) up and running.
+1. Get the [Boot2docker Vagrant Box](https://github.com/frederickjh/boot2docker-vagrant) up and running.
 2. Install [dsh](#dsh) tool (Drude Shell) wrapper
 
     ```
-    curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/install-dsh.sh | bash
+    curl -s https://raw.githubusercontent.com/frederickjh/drude/master/install-dsh.sh | bash
     ```
 
 ### Linux
@@ -24,7 +24,7 @@ Mac and Windows users will need a tiny linux VM layer - [Boot2docker Vagrant Box
 3. Install [dsh](#dsh) tool (Drude Shell) wrapper
 
     ```
-    curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/install-dsh.sh | bash
+    curl -s https://raw.githubusercontent.com/frederickjh/drude/master/install-dsh.sh | bash
     ```
 
 <a name="setup"></a>
@@ -47,7 +47,7 @@ The installation process is slightly different based on the OS.
  3. cd `</path/to/project>` and run:
 
     ```
-    curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/install-drude.sh | bash
+    curl -s https://raw.githubusercontent.com/frederickjh/drude/master/install-drude.sh | bash
     ```
     
  4. Start containers with `dsh up`
@@ -59,7 +59,7 @@ The installation process is slightly different based on the OS.
  3. Open Git Bash shell and cd into `</path/to/project>`, then run:
 
     ```
-    curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/install-drude.sh | bash
+    curl -s https://raw.githubusercontent.com/frederickjh/drude/master/install-drude.sh | bash
     ```
     
  4. Start and login into vagrant, cd into `</path/to/project>`:
@@ -79,7 +79,7 @@ The installation process is slightly different based on the OS.
  3. cd `</path/to/project>` and run:
 
     ```
-    curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/install-drude.sh | bash
+    curl -s https://raw.githubusercontent.com/frederickjh/drude/master/install-drude.sh | bash
     ```
 
  4. Start containers with `dsh up`
@@ -89,7 +89,7 @@ The installation process is slightly different based on the OS.
 
 To update Drude run the following from the `</path/to/project>` folder:
 
-    curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/install-drude.sh | bash
+    curl -s https://raw.githubusercontent.com/frederickjh/drude/master/install-drude.sh | bash
 
 Review the changes, revert any local overrides that were reset and commit into your project git repo.
 
@@ -125,7 +125,7 @@ It runs on Mac/Linux directly. On Windows `dsh` runs inside the boot2docker VM.
 
 ### Installation
 
-    curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/install-dsh.sh | bash
+    curl -s https://raw.githubusercontent.com/frederickjh/drude/master/install-dsh.sh | bash
 
 This will install a local dsh wrapper into `/usr/local/bin/dsh`.
 The actual dsh script resides in each project individually (in `.docker/bin/dsh`) and is installed into the project along with Drude. The wrapper makes it possible to use `dsh` from anywhere in the project tree.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Drude (**Dru**pal **D**ocker **E**nvironment)
 Docker and Docker Compose based environment for Drupal.
 
-[![Circle CI](https://circleci.com/gh/frederickjh/drude.svg?style=shield)](https://circleci.com/gh/frederickjh/drude)
+[![Circle CI](https://circleci.com/gh/frederickjh/drude.svg?style=shield)](https://circleci.com/gh/blinkreaction/drude)
 
 <a name="requirements"></a>
 ## Requirements

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ dependencies:
     # Replace sh with bash
     - sudo ln -sf /bin/bash /bin/sh
     # Install dsh wrapper
-    - curl -s https://raw.githubusercontent.com/blinkreaction/drude/master/scripts/dsh-wrapper.sh | sudo tee 1>/dev/null /usr/local/bin/dsh
+    - curl -s https://raw.githubusercontent.com/frederickjh/drude/master/scripts/dsh-wrapper.sh | sudo tee 1>/dev/null /usr/local/bin/dsh
     - sudo chmod +x /usr/local/bin/dsh
 
 ## Customize test commands
@@ -31,7 +31,7 @@ test:
   pre:
   override:
     # Download "drude-testing" repo
-    - wget https://github.com/blinkreaction/drude-testing/archive/master.zip && unzip -q master.zip && mv drude-testing-master/* .
+    - wget https://github.com/frederickjh/drude-testing/archive/master.zip && unzip -q master.zip && mv drude-testing-master/* .
     # Spin up the docker environment
     - docker-compose -f circle.docker-compose.yml up -d
     # Install Drupal with Drush

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Console colors
 red='\033[0;31m'

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -7,8 +7,8 @@ yellow='\033[1;33m'
 NC='\033[0m'
 
 # Drude repo
-DRUDE_REPO='https://github.com/blinkreaction/drude.git'
-DRUDE_REPO_RAW='https://raw.githubusercontent.com/blinkreaction/drude/master'
+DRUDE_REPO='https://github.com/frederickjh/drude.git'
+DRUDE_REPO_RAW='https://raw.githubusercontent.com/frederickjh/drude/master'
 
 # Install/update dsh tool wrapper
 curl -s "$DRUDE_REPO_RAW/install.sh" | bash

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# Next line added for testing.
-set -x
+
 # Console colors
 red='\033[0;31m'
 green='\033[0;32m'

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -11,7 +11,7 @@ DRUDE_REPO='https://github.com/frederickjh/drude.git'
 DRUDE_REPO_RAW='https://raw.githubusercontent.com/frederickjh/drude/master'
 
 # Install/update dsh tool wrapper
-curl -s "$DRUDE_REPO_RAW/install.sh" | bash
+curl -s "$DRUDE_REPO_RAW/install-dsh.sh" | bash
 
 # Check that git binary is available
 type git > /dev/null 2>&1 || { echo -e >&2 "${red}No git? Srsly? \n${yellow}Please install git then come back. Aborting...${NC}"; exit 1; }

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Next line added for testing.
+set -x
 # Console colors
 red='\033[0;31m'
 green='\033[0;32m'

--- a/install-drude.sh
+++ b/install-drude.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Console colors
 red='\033[0;31m'
 green='\033[0;32m'

--- a/install-dsh.sh
+++ b/install-dsh.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Console colors
 red='\033[0;31m'

--- a/install-dsh.sh
+++ b/install-dsh.sh
@@ -7,8 +7,8 @@ yellow='\033[1;33m'
 NC='\033[0m'
 
 # Drude repo
-DRUDE_REPO='https://github.com/blinkreaction/drude.git'
-DRUDE_REPO_RAW='https://raw.githubusercontent.com/blinkreaction/drude/master'
+DRUDE_REPO='https://github.com/frederickjh/drude.git'
+DRUDE_REPO_RAW='https://raw.githubusercontent.com/frederickjh/drude/master'
 
 # Determine if we have sudo
 SUDO='sudo'


### PR DESCRIPTION
I changed scripts in master and build branches to use /bin/bash instead of /bin/sh for Ubuntu linux and possibly other Linuxes as well. 

The default shell in OSx since Panther is bash. It appears that sh under OSx is either a copy of bash or a link to it.

Ubuntu Linux links /bin/sh to /bin/dash.  For some reason dash does not like some of your scripts.

The reality is if you are writing the scripts in bash then it is best to call it. Calling sh which in many cases is a link to another shell that may or may not function will not allow OS portability.

You will not want to merge the links that I changed to allow me to test on the fork of the repo so that it would not go back to the original repo for files.

You will also want to merge the one commit in the build branch in addition to the commits in the master branch.
