### PR TITLE
Changing shell to bash in build branch.

### DIFF
--- a/.docker/bin/dsh
+++ b/.docker/bin/dsh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 help ()
 {


### PR DESCRIPTION
I changed scripts in master and build branches to use /bin/bash instead of /bin/sh for Ubuntu linux and possibly other Linuxes as well. 

The default shell in OSx since Panther is bash. It appears that sh under OSx is either a copy of bash or a link to it.

Ubuntu Linux links /bin/sh to /bin/dash.  For some reason dash does not like some of your scripts.

The reality is if you are writing the scripts in bash then it is best to call it. Calling sh which in many cases is a link to another shell that may or may not function will not allow OS portability.

You will not want to merge the links that I changed to allow me to test on the fork of the repo so that it would not go back to the original repo for files.

You will also want to merge the one commit in the build branch in addition to the commits in the master branch.
