### PR TITLE
Add example on how to keep the DB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ db:
   volumes:
      # MySQL configuration overrides
      - "./.drude/etc/mysql/my.cnf:/etc/mysql/conf.d/z_my.cnf"
+     # Uncomment the followinf line to keep the DB, even if the container is destroyed.
+     #- "./db:/var/lib/mysql"
 
 # CLI node
 # Used for all console commands and tools.


### PR DESCRIPTION
If the container is killed, the DB usually goes the same way. This example show how to keep the data even is the container dies.
