### PR TITLE
Release v1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Docker and Docker Compose based environment for Drupal.
 
-**For a fully working example of Drude setup take a loot at:**
+**For a fully working example of Drude setup take a look at:**
  - [Drupal 7 sample project](https://github.com/blinkreaction/drude-d7-testing)
  - [Drupal 8 sample project](https://github.com/blinkreaction/drude-d8-testing)
 

--- a/bin/dsh
+++ b/bin/dsh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DSH_VERSION=1.9.1
+DSH_VERSION=1.9.2
 
 help ()
 {
@@ -892,7 +892,7 @@ _bash ()
 			container_name="$1"
 		fi
 		local container_id
-		container_id='$(docker-compose ps -q '$container_name')';
+		container_id='$(docker_compose ps -q '$container_name')';
 		# Drop /cygdrive prefix if the working directory is opened as /cygdrive/<driveletter>/.. instead of /<driveletter>.. 
 		cwd=$(pwd); cwd=${cwd#/cygdrive}
 		command="cd $cwd && docker exec -it $container_id bash -i";
@@ -1170,15 +1170,15 @@ _set_cli_uid ()
 	# Let uid to be set with the DRUDE_SET_UID env variable
 	if [[ $DRUDE_SET_UID != "" ]]; then
 		local host_uid=$DRUDE_SET_UID
-		local container_uid=$(docker exec $(docker-compose ps -q cli) id -u)
+		local container_uid=$(docker exec $(docker_compose ps -q cli) id -u)
 
 		if [[ $container_uid != $host_uid ]]; then
 			echo-green "Changing user uid in cli from $container_uid to $host_uid..."
-			docker exec -it -u root $(docker-compose ps -q cli) usermod -u $host_uid docker
+			docker exec -it -u root $(docker_compose ps -q cli) usermod -u $host_uid docker
 			echo-green "Reseting permissions on /var/www..."
-			docker exec -it -u root $(docker-compose ps -q cli) chown -R docker:users /var/www
+			docker exec -it -u root $(docker_compose ps -q cli) chown -R docker:users /var/www
 			echo-green "Restarting php daemon..."
-			docker exec -it -u root $(docker-compose ps -q cli) supervisorctl restart php5-fpm
+			docker exec -it -u root $(docker_compose ps -q cli) supervisorctl restart php5-fpm
 		else
 			echo-green "Container and host uids already match ($container_uid)."
 		fi


### PR DESCRIPTION
- Fix a really tiny typo in the README. be0ee80
- Bump dsh to v1.9.2
  - Fix DRUDE_SET_UID usage (experimental) when combined with DRUDE_DC_PROJECT.  7662291
