### PR TITLE
Fixes #87: the issue with line breaks on Mac when running dsh stop

### DIFF
--- a/bin/dsh
+++ b/bin/dsh
@@ -135,8 +135,12 @@ version ()
 # Use this function for every docker-compose invocation.
 docker_compose ()
 {
-	# Trim CR(\r) from the output, otherwise there will be issues passing it to the docker binary on Windows.
-	docker-compose $* | tr -d '\r'
+	if is_windows; then
+		# Trim CR(\r) from the output, otherwise there will be issues passing it to the docker binary on Windows.
+		docker-compose $* | tr -d '\r'
+	else
+		docker-compose $*
+	fi
 }
 
 #-------------------------- Helper functions --------------------------------


### PR DESCRIPTION
This should work. I'm pretty sure there is way to make that work on one line, and not use the if else, but the pipe makes it hard.
