### PR TITLE
Add feature that can (re)-start the DNS and proxy container

### DIFF
--- a/bin/dsh
+++ b/bin/dsh
@@ -486,6 +486,9 @@ show_help ()
 	echo "	update images		Update container images"
 	echo "	update dsh		Update dsh itself (ex. dsh self-update)"
 	echo
+  echo "	proxy-reset [service]	(Re)-Start DNS and Proxy services that handles *.drude domains."
+  echo "				Service can be 'dns' or 'proxy'. If none specified, both will be reset."
+	echo
 	echo "	version	(-v)		Print dsh version"
 	echo
 }
@@ -658,6 +661,23 @@ install_prerequisites ()
 	fi
 }
 
+# Restart DNS and proxy container.
+dns_proxy_reset()
+{
+
+  if [[ -z "$1" || "$1" == "proxy" ]] ; then
+    sudo docker rm -f vhost-proxy || true
+    sudo docker run -d --name vhost-proxy -p 192.168.10.10:80:80 -p 192.168.10.10:443:443 --restart=always \
+    -v /var/run/docker.sock:/tmp/docker.sock blinkreaction/nginx-proxy:stable
+  fi
+
+  if [[ -z "$1" || "$1" == "dns" ]] ; then
+    sudo docker rm -f dns || true
+    sudo docker run -d --name dns -p 192.168.10.10:53:53/udp --cap-add=NET_ADMIN --dns 8.8.8.8 --restart=always \
+    -v /var/run/docker.sock:/var/run/docker.sock blinkreaction/dns-discovery:stable
+  fi
+}
+
 # Simple function to convert a version number into a string usable for comparison in bash
 _get_version_str () { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
 
@@ -701,15 +721,11 @@ EOF
 	fi
 
 	echo-green "Creating Drude HTTP/HTTPS reverse proxy..."
-	sudo docker rm -f vhost-proxy || true
-	sudo docker run -d --name vhost-proxy -p 192.168.10.10:80:80 -p 192.168.10.10:443:443 --restart=always \
-	-v /var/run/docker.sock:/tmp/docker.sock blinkreaction/nginx-proxy:stable
+  dns_proxy_reset proxy
 	if_failed "Drude HTTP/HTTPS reverse proxy setup failed."
 
 	echo-green "Creating Drude DNS service..."
-	sudo docker rm -f dns || true
-	sudo docker run -d --name dns -p 192.168.10.10:53:53/udp --cap-add=NET_ADMIN --dns 8.8.8.8 --restart=always \
-	-v /var/run/docker.sock:/var/run/docker.sock blinkreaction/dns-discovery:stable
+  dns_proxy_reset dns
 	if [[ $? == 0 ]]; then
 		echo-green "Configuring host DNS resolver for .drude domain..."
 		echo -e "\n# .drude domain resolution\nnameserver 192.168.10.10" | sudo tee -a  /etc/resolvconf/resolv.conf.d/head
@@ -1372,6 +1388,10 @@ case $1 in
 		shift
 		logs $@
 		;;
+  proxy-reset)
+    shift
+    dns_proxy_reset "$@"
+    ;;
 	"")
 		show_help
 		;;


### PR DESCRIPTION
This feature will give the user the capability of starting the DNS and proxy container in case those got stopped for one reason or another.
