### PR TITLE
Refactor custom commands documentation

### DIFF
--- a/bin/dsh
+++ b/bin/dsh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DSH_VERSION=1.19.0
+DSH_VERSION=1.19.1
 
 # Console colors
 red='\033[0;31m'
@@ -21,7 +21,6 @@ DRUDE_B2D_VERSION="$DRUDE_CONFIG_DIR/b2d_version"
 
 # Where custom commands live
 DRUDE_COMMANDS_PATH=".drude/commands"
-DRUDE_COMMANDS_HELP_EXT="1"
 
 # Network settings
 DRUDE_IP="192.168.10.10"
@@ -492,10 +491,9 @@ show_help ()
 			exit
 		fi
 		# Check for custom command file
-		local custom_helpfile="$commands_path/$1.$DRUDE_COMMANDS_HELP_EXT"
-		if [ -f "$custom_helpfile" ]; then
+		if [ -f "$commands_path/$1" ]; then
 			echo -en "${green}dsh $1${NC} - "
-			cat "$custom_helpfile"
+			cat "$commands_path/$1" | grep '^##' | sed "s/^##[ ]*//g"
 			echo
 			exit
 		fi
@@ -566,16 +564,16 @@ show_help ()
 
 	# Show list of custom commands and their help if available
 	if [ ! -z "$(get_drude_path)" ]; then
-		custom_commands_list=$(ls "$commands_path" 2>/dev/null | grep -v .$DRUDE_COMMANDS_HELP_EXT | tr "\n" " ")
+		custom_commands_list=$(ls "$commands_path" 2>/dev/null | tr "\n" " ")
 		if [ ! -z "$custom_commands_list" ]; then
 			echo
 			echo -e "Custom commands found in ${yellow}$DRUDE_COMMANDS_PATH${NC}:";
 			for cmd_name in $custom_commands_list
 			do
-				custom_helpfile="$commands_path/$cmd_name.$DRUDE_COMMANDS_HELP_EXT"
-				local cmd_desc=$(head -1 "$custom_helpfile" 2>/dev/null)
-				cmd_desc=${cmd_desc:-No description}
-				echo "	$cmd_name		$cmd_desc"
+				# command description is lines that start with ##
+				local cmd_desc=$(cat "$commands_path/$cmd_name" | grep '^##' | sed "s/^##[ ]*//g" | head -1 --)
+				printf "\t%-23s" $cmd_name
+				echo "	$cmd_desc"
 			done
 		fi
 	fi
@@ -616,15 +614,6 @@ show_help_reset ()
 	echo -e "	dsh reset proxy		Recreate Drude HTTP/HTTPS reverse proxy service (resolves ${yellow}*.drude${NC} domain names into container IPs)"
 	echo "	dsh reset ssh-agent	Recreate Drude ssh-agent service"
 	echo "	dsh reset system	Recreate all Drude system services"
-	echo
-}
-
-show_help_init ()
-{
-	echo-green "dsh init - Execute project init script (.drude/scripts/drude-init.sh)"
-	echo
-	echo -e "dsh will search for ${yellow}.drude${NC} folder in current and all parent directories."
-	echo -e "When dsh finds first .drude folder it executes ${yellow}scripts/drude-init.sh${NC} from it (if it exists)."
 	echo
 }
 
@@ -1730,8 +1719,7 @@ case $1 in
 			dsh_command_script="$(get_drude_path)/$DRUDE_COMMANDS_PATH/$1"
 		fi
 
-		# second condition does not allow to pass command documentation file as command name
-		if [ -f "$dsh_command_script" ] && [[ "$1" != *".1" ]]; then
+		if [ -f "$dsh_command_script" ]; then
 			if [[ ! -x "$dsh_command_script" ]]; then
 				echo -e "${yellow}$dsh_command_script${NC} is not set to be executable."
 				_confirm "Fix automatically?"

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -2,18 +2,24 @@
 
 Extending DSH with your custom commands is supported in DSH 1.17 and higher.
 
-1. Create a cutom command
+1. Create a custom command
 
     File `.drude/commands/updb` (Notice **no extension**. Script name should match command name)
 
     ```bash
     #!/bin/bash
+    
+    ## Runs drush updb
+    ##
+    ## Usage:	dsh updb [params to passthrough]
+    
     dsh drush updb $1
     ```
 
 2. Set executable bit: `chmod +x .drude/commands/updb`
 3. Use as regular dsh command: `dsh updb`
 4. Passing parameters also works: `dsh updb -y`
+5. See command description in `dsh help` and command full help via `dsh help updb` 
 
 ## Available variables
 
@@ -28,22 +34,54 @@ Example `init` command:
 ```bash
 #!/usr/bin/env bash
 
+## Initialize site
+
 if [ -z "$YML_PATH"]; then
 	cp docker-compose.yml.dist docker-compose.yml
-	dsh up
 fi
+
+# Start containers
+dsh up
+# Install site
+dsh drush site-install -y --site-name="My Drupal site"
+# Get login link
+cd docroot 2>dev/null 
+dsh drush uli
 ```
+
+## Documenting custom command
+
+dsh looks for lines starting with `##` for command documentation. 
+
+```bash
+## Custom command description
+## Usage:	dsh mycommand [--force]
+## Parameters:
+## 		--force		Try really hard
+```
+
+dsh will output first line of custom command documentation as a short decription in `dsh help`.  
+Rest of lines will be available as advanced help via `dsh help command_name`
+
+See example of command documentation in [phpcs command](../examples/.drude/commands/phpcs)
 
 ## Advanced use
 
 It is not imperative to use bash. You can use any interpreter for your custom command scripts
 
 ```python
-#!/usr/bin/python
+#!/usr/bin/env python
 print "Custom python command!"
 ```
 
+```node
+#!/usr/bin/env node
+/*
+## Custom node command description
+*/
+console.log("Custom NodeJS command!")
+```
 
 ## More examples
 
-[phpcs custom command](../examples/.drude/commands)
+[Custom command examples](../examples/.drude/commands)

--- a/examples/.drude/commands/init
+++ b/examples/.drude/commands/init
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+## Sample init script
+
 # Set to the appropriate site directory
 SITE_DIRECTORY='project'
 # Set to the appropriate site directory

--- a/examples/.drude/commands/phpcs
+++ b/examples/.drude/commands/phpcs
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+## Run Code Sniffer (phpcs) against given path
+##
+## Usage: dsh phpcs <path>
+##
+## Uses Drupal standards.
+##
+## Includes extensions:	php, module, inc, install, test, profile, theme
+## Ignores:		features.*, *.pages*.inc
+
 # Environment variables passed from dsh:
 #
 #   $DRUDE_PATH - (string) absolute path to NEAREST .drude folder

--- a/examples/.drude/commands/phpcs.1
+++ b/examples/.drude/commands/phpcs.1
@@ -1,8 +1,0 @@
-Run Code Sniffer (phpcs) against given path
-
-Usage: dsh phpcs <path>
-
-Uses Drupal standards.
-
-Includes extensions:	php, module, inc, install, test, profile, theme
-Ignores:		features.*, *.pages*.inc


### PR DESCRIPTION
dsh will look for custom command documentation inside command file.
Lines starting with `##` will be considered command documentation.
Files like `command.1` are not used anymore
